### PR TITLE
feat uservice-dynconf: made makefile consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,12 @@ test-debug test-release: test-%: build-%
 	pycodestyle tests
 
 # Start the service (via testsuite service runner)
-.PHONY: service-start-debug service-start-release
-service-start-debug service-start-release: service-start-%:
+.PHONY: start-debug start-release
+start-debug start-release: start-%:
 	cmake --build build_$* -v --target start-uservice-dynconf
+
+.PHONY: service-start-debug service-start-release
+service-start-debug service-start-release: service-start-%: start-%
 
 # Cleanup data
 .PHONY: clean-debug clean-release
@@ -76,9 +79,12 @@ format:
 		--config_vars /home/user/.local/etc/uservice-dynconf/config_vars.yaml
 
 # Build and run service in docker environment
-.PHONY: docker-start-service-debug docker-start-service-release
-docker-start-service-debug docker-start-service-release: docker-start-service-%:
+.PHONY: docker-start-debug docker-start-release
+docker-start-debug docker-start-release: docker-start-%:
 	$(DOCKER_COMPOSE) run -p 8080:8080 --rm uservice-dynconf-container make -- --in-docker-start-$*
+
+.PHONY: docker-start-service-debug docker-start-service-release
+docker-start-service-debug docker-start-service-release: docker-start-service-%: docker-start-%
 
 # Start targets makefile in docker environment
 .PHONY: docker-cmake-debug docker-build-debug docker-test-debug docker-clean-debug docker-install-debug docker-cmake-release docker-build-release docker-test-release docker-clean-release docker-install-release

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Makefile contains useful targets for development:
 * `make build-release` - release build of the service with LTO
 * `make test-debug` - does a `make build-debug` and runs all the tests on the result
 * `make test-release` - does a `make build-release` and runs all the tests on the result
-* `make service-start-debug` - builds the service in debug mode and starts it
-* `make service-start-release` - builds the service in release mode and starts it
+* `make start-debug` - builds the service in debug mode and starts it
+* `make start-release` - builds the service in release mode and starts it
 * `make` or `make all` - builds and runs all the tests in release and debug modes
 * `make format` - autoformat all the C++ and Python sources
 * `make clean-` - cleans the object files
@@ -69,8 +69,8 @@ Makefile contains useful targets for development:
 * `make docker-COMMAND` - run `make COMMAND` in docker environment
 * `make docker-build-debug` - debug build of the service with all the assertions and sanitizers enabled in docker environment
 * `make docker-test-debug` - does a `make build-debug` and runs all the tests on the result in docker environment
-* `make docker-start-service-release` - does a `make install-release` and runs service in docker environment
-* `make docker-start-service-debug` - does a `make install-debug` and runs service in docker environment
+* `make docker-start-release` - does a `make install-release` and runs service in docker environment
+* `make docker-start-debug` - does a `make install-debug` and runs service in docker environment
 * `make docker-clean-data` - stop docker containers and clean database data
 
 Edit `Makefile.local` to change the default configuration and build options.


### PR DESCRIPTION
There was a discrepancy between local and docker start commands.

This PR make them consistent with backward compatibility